### PR TITLE
Add nullsafety support

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,8 +1,8 @@
 import 'package:maybe/maybe.dart';
 
 class Update {
-  final Maybe<String> title;
-  final Maybe<String> description;
+  final Maybe<String>? title;
+  final Maybe<String>? description;
   Update({this.title, this.description});
 }
 
@@ -17,7 +17,7 @@ void main(args) {
   });
 
   // if is also possible
-  if(isNothing(update.title)) {
+  if (isNothing(update.title)) {
     print("No description");
   }
 

--- a/lib/map.dart
+++ b/lib/map.dart
@@ -4,18 +4,18 @@ import 'package:maybe/maybe.dart';
 
 /**
  * A map with optional values.
- * 
+ *
  * If a [nothing] is added, it removes an old value.
- * 
+ *
  * If a key isn't present in the map, [nothing] is returned as value.
  */
 class MaybeMap<K, V> implements Map<K, Maybe<V>> {
-  final Map<K, V> _map;
+  final Map<K, V?> _map;
   bool _nullable;
 
   /**
    * Creates a [MaybeMap].
-   * 
+   *
    * If [nullable] is `true`, `null` values are considered as `some`.
    */
   MaybeMap({bool nullable = true})
@@ -25,14 +25,14 @@ class MaybeMap<K, V> implements Map<K, Maybe<V>> {
   /**
    * Creates a [MaybeMap] instance that contains all key/value pairs of
    * [map] as [some].
-   * 
+   *
    * If [nullable] is `true`, `null` values are considered as `some`.
    */
   MaybeMap.fromMap(this._map, {bool nullable = true})
       : this._nullable = nullable;
 
   @override
-  Maybe<V> operator [](Object key) {
+  Maybe<V> operator [](Object? key) {
     if (!_map.containsKey(key)) {
       return Maybe<V>.nothing();
     }
@@ -69,12 +69,12 @@ class MaybeMap<K, V> implements Map<K, Maybe<V>> {
   void clear() => this._map.clear();
 
   @override
-  bool containsKey(Object key) => this._map.containsKey(key);
+  bool containsKey(Object? key) => this._map.containsKey(key);
 
   @override
-  bool containsValue(Object value) {
+  bool containsValue(Object? value) {
     if (value is Maybe<V> && !isNothing(value)) {
-      return this._map.containsValue(some(value, null));
+      return this._map.containsValue(some<V>(value, null));
     }
     if (value == null) {
       this._map.containsValue(null);
@@ -121,7 +121,7 @@ class MaybeMap<K, V> implements Map<K, Maybe<V>> {
   }
 
   @override
-  Maybe<V> remove(Object key) {
+  Maybe<V> remove(Object? key) {
     if (this.containsKey(key)) {
       var v = this._map.remove(key);
       return Maybe.some(v, nullable: true);
@@ -136,7 +136,7 @@ class MaybeMap<K, V> implements Map<K, Maybe<V>> {
 
   @override
   Maybe<V> update(K key, Maybe<V> Function(Maybe<V> value) update,
-      {Maybe<V> Function() ifAbsent}) {
+      {Maybe<V> Function()? ifAbsent}) {
     if (this.containsKey(key)) {
       var oldValue = this[key];
       var updated = update(oldValue);
@@ -163,8 +163,8 @@ class MaybeMap<K, V> implements Map<K, Maybe<V>> {
   Iterable<Maybe<V>> get values =>
       this._map.values.map((v) => Maybe.some(v, nullable: _nullable));
 
-  MapEntry<K, Maybe<V>> _mapEntry(MapEntry<K, V> entry) =>
+  MapEntry<K, Maybe<V>> _mapEntry(MapEntry<K, V?> entry) =>
       MapEntry<K, Maybe<V>>(entry.key, _someValue(entry.value));
 
-  Maybe<V> _someValue(V v) => Maybe.some(v, nullable: true);
+  Maybe<V> _someValue(V? v) => Maybe.some(v, nullable: true);
 }

--- a/lib/maybe.dart
+++ b/lib/maybe.dart
@@ -3,11 +3,11 @@ export 'map.dart';
 /**
  * Extracts value from [maybe] if not nothing, else returns [defaultValue].
  */
-T some<T>(Maybe<T> maybe, T defaultValue) {
+T? some<T>(Maybe<T>? maybe, T? defaultValue) {
   if (isNothing(maybe)) {
     return defaultValue;
   }
-  return maybe._value;
+  return maybe!._value;
 }
 
 /**
@@ -16,18 +16,18 @@ T some<T>(Maybe<T> maybe, T defaultValue) {
  * If [maybe] is nothing, `Maybe<U>.nothing()` is returned, else `Maybe.some` from
  * the value obtained from the [converter] with the original value.
  */
-Maybe<U> mapSome<T, U>(Maybe<T> maybe, U converter(T v)) {
+Maybe<U> mapSome<T, U>(Maybe<T>? maybe, U? converter(T? v)?) {
   if (isNothing(maybe)) {
     return Maybe<U>.nothing();
   }
   assert(converter != null, "a [converter] must be precised");
-  return Maybe.some(converter(maybe._value));
+  return Maybe.some(converter!(maybe?._value));
 }
 
 /**
  * Tests if [maybe] is nothing.
  */
-bool isNothing<T>(Maybe<T> maybe) {
+bool isNothing<T>(Maybe<T>? maybe) {
   if (maybe == null || maybe._isNothing) {
     return true;
   }
@@ -37,15 +37,17 @@ bool isNothing<T>(Maybe<T> maybe) {
 /**
  * Tests if [maybe] is some.
  */
-bool isSome<T>(Maybe<T> maybe) => !isNothing(maybe);
+bool isSome<T>(Maybe<T>? maybe) => !isNothing(maybe);
 
 /**
  * Tests the [maybe] status : executes [some] if it contains a value, [whenNothing] if not.
  *
  * When adding [defaultValue], [isSome] is called with the value instead of [isNothing].
  */
-void when<T>(Maybe<T> maybe,
-    {MaybeNothing nothing, MaybeSome<T> some, MaybeDefault<T> defaultValue}) {
+void when<T>(Maybe<T>? maybe,
+    {MaybeNothing? nothing,
+    MaybeSome<T>? some,
+    MaybeDefault<T>? defaultValue}) {
   if (isNothing(maybe)) {
     if (defaultValue != null) {
       if (some != null) {
@@ -55,7 +57,7 @@ void when<T>(Maybe<T> maybe,
       nothing();
     }
   } else if (some != null) {
-    some(maybe._value);
+    some(maybe!._value);
   }
 }
 
@@ -66,7 +68,7 @@ void when<T>(Maybe<T> maybe,
  */
 class Maybe<T> {
   bool _isNothing;
-  final T _value;
+  final T? _value;
 
   /**
    * An empty value.
@@ -82,7 +84,7 @@ class Maybe<T> {
    *
    * If [nothingWhen], considered as [nothing] when predicate is verified.
    */
-  Maybe.some(this._value, {bool nullable = false, bool nothingWhen(T value)})
+  Maybe.some(this._value, {bool nullable = false, bool nothingWhen(T? value)?})
       : this._isNothing = (!nullable && _value == null) ||
             (nothingWhen != null && nothingWhen(_value));
 
@@ -94,7 +96,7 @@ class Maybe<T> {
   /**
    * Delegates to the underlying [_value] == operator when possible.
    */
-  bool operator ==(o) {
+  bool operator ==(Object? o) {
     if (o is Maybe<T>) {
       var oNothing = isNothing(o);
       var thisNothing = isNothing(this);
@@ -112,11 +114,11 @@ class Maybe<T> {
   /**
    *  Flattens two nested [maybe] into one.
    */
-  static Maybe<T> flatten<T>(Maybe<Maybe<T>> maybe) {
+  static Maybe<T> flatten<T>(Maybe<Maybe<T>>? maybe) {
     if (maybe == null || maybe._isNothing) {
       return Maybe.nothing();
     }
-    return maybe._value;
+    return maybe._value!;
   }
 
   /**
@@ -125,23 +127,24 @@ class Maybe<T> {
    * The matching elements have the same order in the returned iterable
    * as they have in [maybeIterable].
    */
-  static Iterable<T> filter<T>(Iterable<Maybe<T>> maybeIterable) {
+  static Iterable<T?> filter<T>(Iterable<Maybe<T>?>? maybeIterable) {
     return (maybeIterable == null)
         ? Iterable<T>.empty()
         : maybeIterable
             .where((v) => v != null && !v._isNothing)
-            .map((v) => v._value);
+            .map((v) => v!._value);
   }
 
   /**
    * Applies the function [f] to each element with a value of [maybeIterable] collection
    * in iteration order.
    */
-  static void forEach<T>(Iterable<Maybe<T>> maybeIterable, void f(T element)) {
-    if (maybeIterable == null) {
+  static void forEach<T>(
+      Iterable<Maybe<T>?>? maybeIterable, void f(T? element)) {
+    if (maybeIterable != null) {
       maybeIterable
           .where((v) => v != null && !v._isNothing)
-          .map((v) => v._value)
+          .map((v) => v!._value)
           .forEach(f);
     }
   }
@@ -149,7 +152,7 @@ class Maybe<T> {
   /**
    * Returns the number of elements with a value in [maybeIterable].
    */
-  static int count<T>(Iterable<Maybe<T>> maybeList) {
+  static int count<T>(Iterable<Maybe<T>?>? maybeList) {
     return (maybeList == null)
         ? 0
         : maybeList.where((v) => v != null && !v._isNothing).length;
@@ -158,6 +161,6 @@ class Maybe<T> {
 
 typedef void MaybeNothing();
 
-typedef void MaybeSome<T>(T value);
+typedef void MaybeSome<T>(T? value);
 
-typedef T MaybeDefault<T>();
+typedef T? MaybeDefault<T>();

--- a/lib/maybe_iterables.dart
+++ b/lib/maybe_iterables.dart
@@ -6,7 +6,7 @@ import 'package:maybe/maybe.dart';
 * The matching elements have the same order in the returned iterable
 * as they have in [maybeIterable].
 */
-Iterable<T> filter<T>(Iterable<Maybe<T>> maybeIterable) {
+Iterable<T?> filter<T>(Iterable<Maybe<T>?>? maybeIterable) {
   return (maybeIterable == null)
       ? Iterable<T>.empty()
       : maybeIterable.where((v) => !isNothing(v)).map((v) => some(v, null));
@@ -16,7 +16,7 @@ Iterable<T> filter<T>(Iterable<Maybe<T>> maybeIterable) {
  * Applies the function [f] to each element with a value of [maybeIterable] collection
  * in iteration order.
  */
-void forEach<T>(Iterable<Maybe<T>> maybeIterable, void f(T element)) {
+void forEach<T>(Iterable<Maybe<T>?>? maybeIterable, void f(T? element)) {
   if (maybeIterable != null) {
     maybeIterable
         .where((v) => !isNothing(v))
@@ -28,6 +28,6 @@ void forEach<T>(Iterable<Maybe<T>> maybeIterable, void f(T element)) {
 /**
  * Returns the number of elements with a value in [maybeIterable].
  */
-int count<T>(Iterable<Maybe<T>> maybeList) {
+int count<T>(Iterable<Maybe<T>?>? maybeList) {
   return (maybeList == null) ? 0 : maybeList.where((v) => !isNothing(v)).length;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,6 @@ authors:
   - Aloïs Deniel <alois.deniel@outlook.com>
 homepage: https://github.com/aloisdeniel/dart_maybe
 environment:
-    sdk: ">=2.2.0 <3.0.0"
+    sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
   test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: maybe
 description: An helper for ensuring that values are checked before they are used.
-version: 0.4.0
+version: 0.5.0
 authors:
   - Aloïs Deniel <alois.deniel@outlook.com>
 homepage: https://github.com/aloisdeniel/dart_maybe

--- a/test/map.dart
+++ b/test/map.dart
@@ -5,7 +5,7 @@ void main() {
   group("MaybeMap", () {
     group("fromMap", () {
       test("valid map", () {
-        final map = <String, String>{
+        final map = <String, String?>{
           "1": "2",
           "3": "4",
           "5": null,
@@ -39,7 +39,7 @@ void main() {
         expect(isNothing(actual), equals(false));
         expect(actual, Maybe.some("2"));
       });
-      test("not containted value", () {
+      test("not contained value", () {
         var map = MaybeMap<String, String>();
         map["1"] = Maybe.some("2");
         var actual = map["2"];

--- a/test/maybe.dart
+++ b/test/maybe.dart
@@ -7,10 +7,10 @@ void main() {
       test("[isSome] is called with some value", () {
         // Defining a value
         var maybe = Maybe.some("hello world");
-        var actual = "";
+        String? actual = "";
         when(maybe,
             nothing: () => actual = "nothing",
-            some: (String v) {
+            some: (String? v) {
               actual = v;
             });
         expect(actual, equals("hello world"));
@@ -65,8 +65,8 @@ void main() {
       test("[some] is called with nothing and defaultValue", () {
         // Defining a value
         var maybe = Maybe<String>.nothing();
-        var actual = "";
-        when(maybe,
+        String? actual = "";
+        when<String>(maybe,
             nothing: () {
               actual = "nothing";
             },
@@ -162,26 +162,26 @@ void main() {
         // Defining a value
         var maybe = Maybe.some(Maybe<String>.some("some"));
         var flatten = Maybe.flatten(maybe);
-        var actual = "";
-        when(flatten, some: (v) => actual = v);
+        String? actual = "";
+        when<String>(flatten, some: (v) => actual = v);
         expect(actual, equals("some"));
       });
     });
     group(".mapSome", () {
       test("(nothing) returns nothing'", () {
         var maybe = Maybe<String>.nothing();
-        var converter = mapSome<String, int>(maybe, (v) => v.length);
+        var converter = mapSome<String, int>(maybe, (v) => v?.length);
         expect(isNothing(converter), equals(true));
       });
 
       test("(null) returns nothing'", () {
-        var converter = mapSome<String, int>(null, (v) => v.length);
+        var converter = mapSome<String, int>(null, (v) => v?.length);
         expect(isNothing(converter), equals(true));
       });
 
       test("(some) returns a converted value'", () {
         var maybe = Maybe.some("hello world");
-        var converter = mapSome<String, int>(maybe, (v) => v.length);
+        var converter = mapSome<String, int>(maybe, (v) => v?.length);
         expect(some(converter, 0), equals(11));
       });
     });

--- a/test/maybe_iterables.dart
+++ b/test/maybe_iterables.dart
@@ -4,7 +4,7 @@ import "package:test/test.dart";
 
 void main() {
   group("Iterables", () {
-    var maybeList = [
+    var maybeList = <Maybe<String>?>[
       Maybe.some("start"),
       Maybe.nothing(),
       null,


### PR DESCRIPTION
I've updated the `dart_maybe` files to support the dart null safety feature.

This is a breaking change that requires the `dart` `sdk` to be updated.

Feel free to take what you will from this, or throw it all away, it's my goal here to be more helpful than harmful for this dependency.

Please let me know if you have any questions,

Thanks,

~ Ayiga